### PR TITLE
Improve recursive copy handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx tests/copy.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.5.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,11 @@ import { existsSync } from "fs";
 import { exec } from "child_process";
 import { promisify } from "util";
 import * as os from "os";
+import { pathToFileURL } from "url";
 
 const execAsync = promisify(exec);
 
-class CrossPlatformFilesystemMCP {
+export class CrossPlatformFilesystemMCP {
   private server: Server;
   private baseDir: string;
   private platform: string;
@@ -110,12 +111,35 @@ class CrossPlatformFilesystemMCP {
     }
   }
 
-  private async getCopyCommand(source: string, destination: string): Promise<string> {
+  private quotePath(filePath: string): string {
+    if (this.platform === 'win32') {
+      const escaped = filePath.replace(/"/g, '""');
+      return `"${escaped}"`;
+    }
+
+    const escaped = filePath.replace(/(["\\\$`])/g, "\\$1");
+    return `"${escaped}"`;
+  }
+
+  private async getCopyCommand(
+    source: string,
+    destination: string,
+    isDirectory: boolean
+  ): Promise<string> {
+    const quotedSource = this.quotePath(source);
+    const quotedDestination = this.quotePath(destination);
+
     switch (this.platform) {
       case 'win32':
-        return `copy "${source}" "${destination}"`;
+        if (isDirectory) {
+          return `xcopy ${quotedSource} ${quotedDestination} /E /I /Y`;
+        }
+        return `copy ${quotedSource} ${quotedDestination}`;
       default:
-        return `cp "${source}" "${destination}"`;
+        if (isDirectory) {
+          return `cp -R ${quotedSource} ${quotedDestination}`;
+        }
+        return `cp ${quotedSource} ${quotedDestination}`;
     }
   }
 
@@ -589,14 +613,16 @@ class CrossPlatformFilesystemMCP {
   private async copyItem(source: string, destination: string) {
     const resolvedSource = this.validatePath(source);
     const resolvedDestination = this.validatePath(destination);
-    
+
     try {
       // For cross-platform compatibility, check if it's a directory
       const stats = await fs.stat(resolvedSource);
-      
+
+      await fs.mkdir(path.dirname(resolvedDestination), { recursive: true });
+
       if (stats.isDirectory()) {
         // Use shell command for directory copying
-        const command = await this.getCopyCommand(resolvedSource, resolvedDestination);
+        const command = await this.getCopyCommand(resolvedSource, resolvedDestination, true);
         await execAsync(command);
       } else {
         await fs.copyFile(resolvedSource, resolvedDestination);
@@ -712,5 +738,20 @@ class CrossPlatformFilesystemMCP {
   }
 }
 
-const server = new CrossPlatformFilesystemMCP();
-server.run().catch(console.error);
+const isDirectExecution = (() => {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  try {
+    const invokedPath = path.resolve(process.argv[1]);
+    return pathToFileURL(invokedPath).href === import.meta.url;
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectExecution) {
+  const server = new CrossPlatformFilesystemMCP();
+  server.run().catch(console.error);
+}

--- a/tests/copy.test.ts
+++ b/tests/copy.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { CrossPlatformFilesystemMCP } from "../src/index.js";
+
+async function testFileCopy() {
+  const instance = new CrossPlatformFilesystemMCP();
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-copy-file-"));
+  const sourceFile = path.join(tempDir, "source.txt");
+  const destinationFile = path.join(tempDir, "destination.txt");
+
+  await fs.writeFile(sourceFile, "hello world", "utf8");
+
+  const result = await (instance as any).copyItem(sourceFile, destinationFile);
+
+  const copiedContent = await fs.readFile(destinationFile, "utf8");
+  assert.equal(copiedContent, "hello world", "file contents should match after copy");
+  assert.ok(result.content[0].text.includes("Copied"), "response should include success message");
+
+  await fs.rm(tempDir, { recursive: true, force: true });
+}
+
+async function testDirectoryCopy() {
+  if (process.platform === "win32") {
+    console.warn("Skipping directory copy integration test on Windows");
+    return;
+  }
+
+  const instance = new CrossPlatformFilesystemMCP();
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-copy-dir-"));
+  const sourceDir = path.join(tempDir, "source dir");
+  const nestedDir = path.join(sourceDir, "nested");
+  const nestedFile = path.join(nestedDir, "example.txt");
+  const destinationDir = path.join(tempDir, "destination dir");
+
+  await fs.mkdir(nestedDir, { recursive: true });
+  await fs.writeFile(nestedFile, "nested content", "utf8");
+
+  const result = await (instance as any).copyItem(sourceDir, destinationDir);
+  assert.ok(result.content[0].text.includes("Copied"), "response should include success message");
+
+  const copiedFile = path.join(destinationDir, "nested", "example.txt");
+  const copiedContent = await fs.readFile(copiedFile, "utf8");
+  assert.equal(copiedContent, "nested content", "directory copy should include nested files");
+
+  await fs.rm(tempDir, { recursive: true, force: true });
+}
+
+async function testCopyCommands() {
+  const instance = new CrossPlatformFilesystemMCP();
+
+  (instance as any).platform = "linux";
+  let command = await (instance as any).getCopyCommand("/tmp/source dir", "/tmp/destination dir", true);
+  assert.equal(command, 'cp -R "/tmp/source dir" "/tmp/destination dir"', "posix directory copy should use cp -R");
+
+  command = await (instance as any).getCopyCommand("/tmp/source.txt", "/tmp/destination.txt", false);
+  assert.equal(command, 'cp "/tmp/source.txt" "/tmp/destination.txt"', "posix file copy should use cp");
+
+  (instance as any).platform = "win32";
+  command = await (instance as any).getCopyCommand("C:\\source dir", "C:\\destination dir", true);
+  assert.equal(command, 'xcopy "C:\\source dir" "C:\\destination dir" /E /I /Y', "windows directory copy should use xcopy with recursion");
+
+  command = await (instance as any).getCopyCommand("C:\\source.txt", "C:\\destination.txt", false);
+  assert.equal(command, 'copy "C:\\source.txt" "C:\\destination.txt"', "windows file copy should use copy");
+}
+
+async function main() {
+  await testFileCopy();
+  await testDirectoryCopy();
+  await testCopyCommands();
+  console.log("All copy tests passed");
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- adjust copy command generation to quote paths safely and select recursive tools per platform
- ensure directory copies use the recursive command and create destination parents when needed
- add automated tests and npm script covering file and directory copy behavior and command selection

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdd4b660548324a6e532fb70abc4c3