### PR TITLE
Add runtime installation script and fix README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ npm run build
 npm run dev
 ```
 
+### 4. Install to a Runtime Directory (Optional)
+```bash
+./scripts/install-runtime.sh
+```
+
+By default the script installs the server into `/opt/mcp-servers/mcp-filesystem-cross-platform`. Use `--prefix` to change the parent directory or `--name` to customize the folder name.
+
 ## 📋 Platform-Specific Allowed Paths
 
 The MCP automatically detects the platform and restricts access to safe directories:
@@ -110,7 +117,7 @@ D:\             # Additional drives
   "mcpServers": {
     "filesystem": {
       "command": "npx",
-      "args": ["tsx", "/path/to/cross-platform-filesystem-mcp/src/index.ts"]
+      "args": ["tsx", "/path/to/mcp-filesystem-cross-platform/src/index.ts"]
     }
   }
 }
@@ -122,7 +129,7 @@ D:\             # Additional drives
   "mcpServers": {
     "filesystem": {
       "command": "npx",
-      "args": ["tsx", "C:\\path\\to\\cross-platform-filesystem-mcp\\src\\index.ts"]
+      "args": ["tsx", "C:\\path\\to\\mcp-filesystem-cross-platform\\src\\index.ts"]
     }
   }
 }
@@ -193,7 +200,7 @@ If you're currently using the macOS-only version, here's how to migrate:
   "mcpServers": {
     "filesystem": {
       "command": "npx",
-      "args": ["tsx", "/path/to/cross-platform-filesystem-mcp/src/index.ts"]
+      "args": ["tsx", "/path/to/mcp-filesystem-cross-platform/src/index.ts"]
     }
   }
 }

--- a/scripts/install-runtime.sh
+++ b/scripts/install-runtime.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: ${0##*/} [--prefix <directory>] [--name <server-name>]
+
+Installs the MCP server into /opt/mcp-servers/<name> by default.
+  --prefix  Installation parent directory (default: /opt/mcp-servers)
+  --name    Folder name for the installation (default: repository directory name)
+USAGE
+}
+
+PREFIX="/opt/mcp-servers"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEFAULT_NAME="$(basename "$PROJECT_ROOT")"
+SERVER_NAME="$DEFAULT_NAME"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefix)
+      [[ $# -lt 2 ]] && { echo "Missing value for --prefix" >&2; usage; exit 1; }
+      PREFIX="$2"
+      shift 2
+      ;;
+    --name)
+      [[ $# -lt 2 ]] && { echo "Missing value for --name" >&2; usage; exit 1; }
+      SERVER_NAME="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+TARGET_DIR="${PREFIX%/}/$SERVER_NAME"
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "Error: npm is required to install the server." >&2
+  exit 1
+fi
+
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "Error: rsync is required to install the server." >&2
+  exit 1
+fi
+
+printf 'Building project in %s\n' "$PROJECT_ROOT"
+(
+  cd "$PROJECT_ROOT"
+  npm install
+  npm run build
+)
+
+echo "Installing to $TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+
+rsync -a --delete \
+  --exclude '.git' \
+  --exclude 'node_modules' \
+  --exclude '.env' \
+  "$PROJECT_ROOT"/ "$TARGET_DIR"/
+
+npm ci --omit=dev --prefix "$TARGET_DIR"
+
+echo "Installation complete. Runtime files are located in $TARGET_DIR"
+echo "Add to your MCP configuration with:"
+echo "  \"args\": [\"node\", \"$TARGET_DIR/dist/index.js\"]"


### PR DESCRIPTION
## Summary
- add a helper script to install the MCP server into a runtime directory under /opt/mcp-servers
- document the runtime installation step in the README and correct the sample configuration paths to match the repository name

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceb48c4f54832483f115803a6fc903